### PR TITLE
Fix Sessions derived table increment

### DIFF
--- a/views/sessions.view.lkml
+++ b/views/sessions.view.lkml
@@ -48,7 +48,7 @@ session_list_with_event_history as (
       , events.platform
       , events.event_dimensions
       , events.ecommerce
-      , events.items
+      , ARRAY(select AS struct it.* EXCEPT(item_params) from unnest(events.items) as it) as items
         from `@{GA4_SCHEMA}.@{GA4_TABLE_VARIABLE}` events
         where {% incrementcondition %} timestamp(PARSE_DATE('%Y%m%d', REGEXP_EXTRACT(_TABLE_SUFFIX,r'[0-9]+'))) {%  endincrementcondition %}
         -- where timestamp(PARSE_DATE('%Y%m%d', REGEXP_EXTRACT(_TABLE_SUFFIX,r'[0-9]+'))) >= ((TIMESTAMP_ADD(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP(), DAY), INTERVAL -29 DAY)))


### PR DESCRIPTION
Since 2023-10-25, `event.items` from **events_** tables contain a new entry `item_params`. 
This new entry prevents the **sessions** incremental derived table from updating : 

```
derived_table sessions creation failed: SQL Error in incremental PDT: Query execution failed: - Value has type ARRAY<STRUCT<sl_key STRING, event_rank INT64, page_view_rank INT64, ...>> which cannot be inserted into column event_data, which has type ARRAY<STRUCT<sl_key STRING, event_rank INT64, page_view_rank INT64, ...>> at [199:311]
```

This patch allows the view update by ignoring `item_params` inside the query.